### PR TITLE
Remove NeedsCompilation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ VignetteBuilder: knitr
 biocViews:
     Clustering,
     GraphAndNetwork
-NeedsCompilation: yes
 URL: https://github.com/libscran/Rigraphlib
 BugReports: https://github.com/libscran/Rigraphlib/issues
 Encoding: UTF-8


### PR DESCRIPTION
There have been some discussion on r-devel about the NeedsCompilation field on DESCRIPTION. See this thread where this package was mentioned explicitly https://stat.ethz.ch/pipermail/r-devel/2025-May/084033.html

I don't really know how [tools/igraph_setup.R](https://github.com/libscran/Rigraphlib/blob/master/tools/igraph_setup.R) file works with the compilation or installation. But I thought it would be better to bring this to your attention. 